### PR TITLE
fix: modify the API Token regex

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ export function genConfigFields(): SomeCompanionConfigField[] {
 			id: 'token',
 			label: 'API Token',
 			width: 12,
-			regex: Regex.SOMETHING,
+			regex: '/^[a-z0-9-]*$/i',
 		},
 		{
 			type: 'textinput',


### PR DESCRIPTION
The regex is modified to check for alphanumeric characters and dashes (characters found in the DHD Control API tokens) but allows for an empty string.

Re: Issue #1