### PR TITLE
fix(generic-action): generic action behavior, state management

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,24 @@
 import { generateEslintConfig } from '@companion-module/tools/eslint/config.mjs'
 
-export default generateEslintConfig({
+const baseConfig = generateEslintConfig({
 	enableTypescript: true,
 })
+
+const customConfig = [
+	...baseConfig,
+	{
+		rules: {
+			'@typescript-eslint/ban-ts-comment': [
+				'error',
+				{
+					'ts-expect-error': false,
+					'ts-ignore': true,
+					'ts-nocheck': true,
+					'ts-check': false,
+				},
+			],
+		},
+	},
+]
+
+export default customConfig

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import { generateEslintConfig } from '@companion-module/tools/eslint/config.mjs'
 
-const baseConfig = generateEslintConfig({
+const baseConfig = await generateEslintConfig({
 	enableTypescript: true,
 })
 

--- a/src/components/generic-action.ts
+++ b/src/components/generic-action.ts
@@ -18,7 +18,7 @@ export function init(self: ModuleInstance): {
 // to parse the subscription updates coming from the websocket
 // we need to know the paths of the subscriptions and corresponding generic variables
 // -- hacky solution
-const genericVariableNames: any = {}
+const genericVariableNames: Record<string, string> = {}
 
 function genVariables(quantity: number): ReadonlyArray<CompanionVariableDefinition> {
 	return Array.from(

--- a/src/components/generic-action.ts
+++ b/src/components/generic-action.ts
@@ -138,7 +138,7 @@ function genActions(self: ModuleInstance, quantity: number): CompanionActionDefi
 				}
 
 				const subscriptionPath = path.toString()
-				self.websocket.subscribe(path.toString())
+				self.websocket.subscribe(subscriptionPath)
 
 				self.websocket.get(
 					path.toString(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,7 +130,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 	}
 
 	onSubscriptionUpdate(update: ResponseSubscriptionUpdate): void {
-		console.log(update)
+		this.log('debug', JSON.stringify(update))
 		channelOnOff.onSubscriptionUpdate(this, update)
 		selector.onSubscriptionUpdate(this, update)
 		faderPfl.onSubscriptionUpdate(this, update)


### PR DESCRIPTION
... and minor refactors

- correctly store variable names per registered path. Old solution only stored the variable name and API path for the last subscribed action
- iterate over all variables mapped to paths to update all generic action states (feedbacks) on subscription updates
- add an option to use the key as a toggle for any boolean path
- use destructured references to some values instead of reusing the original object, for consistency

This PR enables users to use the `Generic Action` to define toggle buttons for various fader channel parameters such as `Automix On`, `Automix Passive`, etc., as well as proper feedback for these parameters using the generic variables.

<img width="1920" height="947" alt="image" src="https://github.com/user-attachments/assets/d79bac0c-054c-4bfd-bd22-83412d36f7ce" />

<img width="782" height="269" alt="image" src="https://github.com/user-attachments/assets/f31f3f05-b0b8-4eb0-9f7c-4fca7010ca0c" />

<img width="778" height="425" alt="image" src="https://github.com/user-attachments/assets/467672e9-94d8-49e3-aae0-367864f5d525" />
