### PR TITLE
feat(snapshot): add a fader channel selector for channel snapshot loading

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 		const faderLevelConfig = faderLevel.init(this, ch)
 		const faderPflConfig = faderPfl.init(this, ch)
 		const selectorConfig = await selector.init(this)
-		const snapshotConfig = await snapshot.init(this)
+		const snapshotConfig = await snapshot.init(this, ch)
 		const logicsConfig = await logics.init(this)
 		const genericActionConfig = genericAction.init(this)
 


### PR DESCRIPTION
instead of using the mixer parameter for the fader ID in case of channel snapshots, use the list of actual channels.

<img width="1920" height="954" alt="image" src="https://github.com/user-attachments/assets/ea65ca33-fcf2-428b-ba83-00d052f21575" />

<img width="778" height="288" alt="image" src="https://github.com/user-attachments/assets/88c933f1-af75-4555-b8d0-44670f13e4ae" />

<img width="778" height="245" alt="image" src="https://github.com/user-attachments/assets/8dc1fa08-8dca-4db4-856e-0c1385b0d704" />

### Things to improve

- instead of using hardcoded type `1` in some of the conditions, using a type enum or something similar (constants, symbols) would be cleaner.
- The presets are just quickly patched for now to set the fader ID to 0 in case of channel snapshots, this could probably be handled a bit better.
- there are a couple of uses of `any` type to avoid typescript's screaming about setting non-predefined properties (ie. when patching in the fader property into the RPC payload) - this can probably be cleaned up in a better way. I am preparing the module to be usable for a demo in a couple of days so I'm currently in a hurry to make things working.