### PR TITLE
feat: add variables for loaded channel snapshots

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 		const faderLevelConfig = faderLevel.init(this, ch)
 		const faderPflConfig = faderPfl.init(this, ch)
 		const selectorConfig = await selector.init(this)
-		const snapshotConfig = await snapshot.init(this)
+		const snapshotConfig = await snapshot.init(this, ch)
 		const logicsConfig = await logics.init(this)
 		const genericActionConfig = genericAction.init(this)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 			...channelOnOffConfig.variables,
 			...faderPflConfig.variables,
 			...selectorConfig.variables,
+			...snapshotConfig.variables,
 			...logicsConfig.variables,
 			...genericActionConfig.variables,
 		])
@@ -134,6 +135,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 		channelOnOff.onSubscriptionUpdate(this, update)
 		selector.onSubscriptionUpdate(this, update)
 		faderPfl.onSubscriptionUpdate(this, update)
+		snapshot.onSubscriptionUpdate(this, update)
 		logics.onSubscriptionUpdate(this, update)
 		genericAction.onSubscriptionUpdate(this, update)
 	}


### PR DESCRIPTION
Useful for displaying a currently loaded channel snapshot in snapshot selection pages (ie. presets for Mic 1 or Phone)

<img width="1661" height="698" alt="image" src="https://github.com/user-attachments/assets/9ed5ab65-ea77-4ecc-bed2-f472d18371a4" />

### Notes

This branch is based off of a personal fork's main branch, which already has all other PRs merged into it. For that reason, I'm making this a draft PR for now. There are also some things that still need to be fixed in this implementation, primarily the lack of support for multiple mixers with these added channel snapshot vars. This is a nice starting point for the concept, but it only works properly with Mixer 0 as of right now.